### PR TITLE
Update 05.c

### DIFF
--- a/ch07/Projects/05.c
+++ b/ch07/Projects/05.c
@@ -12,7 +12,7 @@ int main(void)
         
         switch (toupper(ch)) {
             case 'A': case 'E': case 'I': case 'L': case 'N':
-            case '0': case 'R': case 'S': case 'T': case 'U':
+            case 'O': case 'R': case 'S': case 'T': case 'U':
                 scrabble_value += 1;
                 break;
             case 'D': case 'G':


### PR DESCRIPTION
Replaced "0" with "O": the value for words containing the "O" letter were incorrect (1 less).