### PR TITLE
struct should be declared extern

### DIFF
--- a/ch16/Projects/02/inventory.c
+++ b/ch16/Projects/02/inventory.c
@@ -15,6 +15,7 @@
 #include "readline.h"
 #include "quicksort.h"
 
+struct part inventory[MAX_PARTS];
 
 int num_parts = 0;   /* number of parts currently stored */
 

--- a/ch16/Projects/02/inventory.h
+++ b/ch16/Projects/02/inventory.h
@@ -4,10 +4,10 @@
 #define NAME_LEN 25
 #define MAX_PARTS 100
 
-struct part {
+extern struct part {
   int number;
   char name[NAME_LEN+1];
   int on_hand;
-} inventory[MAX_PARTS];
+} inventory[];
 
 #endif

--- a/ch17/Projects/01_02/inventory.c
+++ b/ch17/Projects/01_02/inventory.c
@@ -164,9 +164,8 @@ void update(void)
 /**********************************************************
  * print: Prints a listing of all parts in the database,  *
  *        showing the part number, part name, and         *
- *        quantity on hand. Parts are printed in the      *
- *        order in which they were entered into the       *
- *        database.                                       *
+ *        quantity on hand. Parts are printed in          *
+ *        order of part numbers                           *
  **********************************************************/
 void print(void)
 {


### PR DESCRIPTION
When the struct is initialized in the header file each time the file gets included it gets initialized result in the following errer
```
/usr/bin/ld: quicksort.o:(.bss+0x0): multiple definition of `inventory'; inventory.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:5: inventory] Error 1
```
the solution is to use extern and only initialize it once in inventory.c.